### PR TITLE
Ensure html field is a string before parsing

### DIFF
--- a/Common/Migration/Phase1/WitBatchRequestGenerators/BaseWitBatchRequestGenerator.cs
+++ b/Common/Migration/Phase1/WitBatchRequestGenerators/BaseWitBatchRequestGenerator.cs
@@ -110,7 +110,8 @@ namespace Common.Migration
 
                     // add inline image urls
                     JsonPatchOperation jsonPatchOperation;
-                    if (this.migrationContext.HtmlFieldReferenceNames.Contains(preparedField.Key))
+                    if (this.migrationContext.HtmlFieldReferenceNames.Contains(preparedField.Key) 
+                        && preparedField.Value is string)
                     {
                         string updatedHtmlFieldValue = GetUpdatedHtmlField((string)preparedField.Value);
                         KeyValuePair<string, object> updatedField = new KeyValuePair<string, object>(preparedField.Key, updatedHtmlFieldValue);


### PR DESCRIPTION
Due to json serialization, if the field is just a date, it won't be a string so skip the additional processing of html fields.