### PR TITLE
Handle the relation URL change in M133 of VSTS

### DIFF
--- a/Common/IContext.cs
+++ b/Common/IContext.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Concurrent;
+using Common.Config;
+
+namespace Common
+{
+    public interface IContext
+    {
+        ConfigJson Config { get; }
+
+        WorkItemClientConnection SourceClient { get; }
+
+        WorkItemClientConnection TargetClient { get; }
+
+        //Mapping of source work items to their url on the source
+        ConcurrentDictionary<int, string> WorkItemIdsUris { get; set; }
+
+        //State of all work items to migrate
+        ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; set; }
+    }
+}

--- a/Common/Migration/Contexts/IMigrationContext.cs
+++ b/Common/Migration/Contexts/IMigrationContext.cs
@@ -6,18 +6,8 @@ using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 
 namespace Common.Migration
 {
-    public interface IMigrationContext
+    public interface IMigrationContext : IContext
     {
-        ConfigJson Config { get; }
-
-        WorkItemClientConnection SourceClient { get; }
-
-        WorkItemClientConnection TargetClient { get; }
-
-        ConcurrentDictionary<int, string> WorkItemIdsUris { get; set; }
-
-        ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; set; }
-
         ConcurrentDictionary<int, int> SourceToTargetIds { get; set; }
 
         //Mapping of targetId of a work item to attribute id of the hyperlink

--- a/Common/RelationHelpers.cs
+++ b/Common/RelationHelpers.cs
@@ -1,22 +1,43 @@
 ﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
-using Common.Migration;
-using Common.Validation;
 
 namespace Common
 {
     public class RelationHelpers
     {
-        public static bool IsRelationHyperlinkToSourceWorkItem(IValidationContext context, WorkItemRelation relation, int sourceId)
+        public static bool IsRelationHyperlinkToSourceWorkItem(IContext context, WorkItemRelation relation, int sourceId)
         {
-            string hyperlinkToSourceWorkItem = context.WorkItemIdsUris[sourceId];
-            return relation.Rel.Equals(Constants.Hyperlink, StringComparison.OrdinalIgnoreCase) && relation.Url.Equals(hyperlinkToSourceWorkItem, StringComparison.OrdinalIgnoreCase);
-        }
+            // only hyperlinks can contain the link to the source work item
+            if (relation.Rel.Equals(Constants.Hyperlink, StringComparison.OrdinalIgnoreCase))
+            {
+                var hyperlinkToSourceWorkItem = context.WorkItemIdsUris[sourceId];
 
-        public static bool IsRelationHyperlinkToSourceWorkItem(IMigrationContext context, WorkItemRelation relation, int sourceId)
-        {
-            string hyperlinkToSourceWorkItem = context.WorkItemIdsUris[sourceId];
-            return relation.Rel.Equals(Constants.Hyperlink, StringComparison.OrdinalIgnoreCase) && relation.Url.Equals(hyperlinkToSourceWorkItem, StringComparison.OrdinalIgnoreCase);
+                var sourceParts = Regex.Split(hyperlinkToSourceWorkItem, "/_apis/wit/workitems/", RegexOptions.IgnoreCase);
+                var targetParts = Regex.Split(relation.Url, "/_apis/wit/workitems/", RegexOptions.IgnoreCase);
+
+                if (sourceParts.Length == 2 && targetParts.Length == 2)
+                {
+                    var sourceIdPart = sourceParts.Last();
+                    var targetIdPart = targetParts.Last();
+
+                    var sourceAccountPart = sourceParts.First().Split("/", StringSplitOptions.RemoveEmptyEntries);
+                    var targetAccountPart = targetParts.First().Split("/", StringSplitOptions.RemoveEmptyEntries);
+
+                    // url of the work item can contain project which we want to ignore since the url we generate does not include project
+                    // and we just need to verify the ids are the same and the account are the same.
+                    if (sourceAccountPart.Length > 1
+                        && targetAccountPart.Length > 1
+                        && string.Equals(sourceIdPart, targetIdPart, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(sourceAccountPart[1], targetAccountPart[1], StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Common/Validation/IValidationContext.cs
+++ b/Common/Validation/IValidationContext.cs
@@ -6,20 +6,8 @@ using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 
 namespace Common.Validation
 {
-    public interface IValidationContext
+    public interface IValidationContext : IContext
     {
-        ConfigJson Config { get; }
-
-        WorkItemClientConnection SourceClient { get; }
-
-        WorkItemClientConnection TargetClient { get; }
-
-        //Mapping of source work items to their url on the source
-        ConcurrentDictionary<int, string> WorkItemIdsUris { get; set; }
-
-        //State of all work items to migrate
-        ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; }
-
         //Mapping of targetId of a work item to attribute id of the hyperlink
         ConcurrentDictionary<int, Int64> TargetIdToSourceHyperlinkAttributeId { get; set; }
 

--- a/Common/Validation/ValidationContext.cs
+++ b/Common/Validation/ValidationContext.cs
@@ -24,7 +24,8 @@ namespace Common.Validation
         public WorkItemClientConnection TargetClient { get; }
 
         public ConcurrentDictionary<int, string> WorkItemIdsUris { get; set; }
-        public ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; private set; } = new ConcurrentBag<WorkItemMigrationState>();
+
+        public ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; set; } = new ConcurrentBag<WorkItemMigrationState>();
 
         //Mapping of targetId of a work item to attribute id of the hyperlink
         public ConcurrentDictionary<int, Int64> TargetIdToSourceHyperlinkAttributeId { get; set; } = new ConcurrentDictionary<int, Int64>();


### PR DESCRIPTION
In M133 VSTS started including projectId as part of the work item URL.  That messes up the logic for the hyperlink back to the source account, so need to react to the change.