### PR TITLE
Use M131 VSTS packages

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.132.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.132.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.131.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.131.0-preview" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />

--- a/Logging/Logging.csproj
+++ b/Logging/Logging.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.132.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.131.0-preview" />
   </ItemGroup>
 
 </Project>

--- a/WiMigrator/WiMigrator.csproj
+++ b/WiMigrator/WiMigrator.csproj
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.132.0-preview" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.132.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="15.131.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="15.131.0-preview" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />


### PR DESCRIPTION
Rollback the VSTS packages to M131 which will continue to enable migration from VSTS -> TFS