### PR TITLE
Fix permission check for bypass rules and suppressnotifications

### DIFF
--- a/Common/Validation/ValidationHelpers.cs
+++ b/Common/Validation/ValidationHelpers.cs
@@ -120,7 +120,6 @@ namespace Common.Validation
                 securityHttpClient = client.Connection.GetClient<SecurityHttpClient>();
                 projectHttpClient = client.Connection.GetClient<ProjectHttpClient>();
                 teamProject = await projectHttpClient.GetProject(project);
-                
             }
             catch (Exception e) when (e.InnerException is VssUnauthorizedException)
             {


### PR DESCRIPTION
I was incorrectly checking the permissions, so while it passed if you were a PCA it wouldn't if you were only an admin on an account.  I needed to check the token on the project, not the area path.