### PR TITLE
Support for remote links as hyperlinks

### DIFF
--- a/Common/BaseContext.cs
+++ b/Common/BaseContext.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using Common.Config;
+
+namespace Common
+{
+    public abstract class BaseContext : IContext
+    {
+        public BaseContext(ConfigJson configJson)
+        {
+            this.Config = configJson;
+            this.SourceClient = ClientHelpers.CreateClient(configJson.SourceConnection);
+            this.TargetClient = ClientHelpers.CreateClient(configJson.TargetConnection);
+        }
+
+        /// <summary>
+        /// Constructor for test purposes
+        /// </summary>
+        public BaseContext()
+        { 
+        }
+
+        public ConfigJson Config { get; }
+
+        public WorkItemClientConnection SourceClient { get; }
+
+        public WorkItemClientConnection TargetClient { get; }
+
+        public ConcurrentDictionary<int, string> WorkItemIdsUris { get; set; }
+
+        public ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; set; } = new ConcurrentBag<WorkItemMigrationState>();
+
+        public ConcurrentDictionary<int, int> SourceToTargetIds { get; set; } = new ConcurrentDictionary<int, int>();
+
+        public ConcurrentSet<string> RemoteLinkRelationTypes { get; set; } = new ConcurrentSet<string>(StringComparer.CurrentCultureIgnoreCase);
+    }
+}

--- a/Common/Constants.cs
+++ b/Common/Constants.cs
@@ -25,8 +25,9 @@ namespace Common
         public const string RelationAttributeGitCommitCommentValue = "(Git Commit Link) Comment: ";
         public const string Fields = "fields";
         public const string Relations = "relations";
-        public const string WorkItemLinkAttributeKey = "usage";
-        public const string WorkItemLinkAttributeValue = "workItemLink";
+        public const string UsageAttributeKey = "usage";
+        public const string UsageAttributeValue = "workItemLink";
+        public const string RemoteLinkAttributeKey = "remote";
 
         public const string TagsFieldReferenceName = "System.Tags";
         public const string TeamProjectReferenceName = "System.TeamProject";
@@ -37,6 +38,7 @@ namespace Common
         public const string RelationPhaseGitCommitLinks = "git commit links";
         public const string RelationPhaseRevisionHistoryAttachments = "revision history attachments";
         public const string RelationPhaseWorkItemLinks = "work item links";
+        public const string RelationPhaseRemoteLinks = "remote work item links";
         public const string RelationPhaseSourcePostMoveTags = "source post move tags";
         public const string RelationPhaseTargetPostMoveTags = "target post move tags";
         
@@ -44,7 +46,8 @@ namespace Common
             RelationPhaseAttachments,
             RelationPhaseGitCommitLinks,
             RelationPhaseRevisionHistoryAttachments,
-            RelationPhaseWorkItemLinks
+            RelationPhaseWorkItemLinks,
+            RelationPhaseRemoteLinks
         });
     }
 }

--- a/Common/Extensions/DictionaryExtensions.cs
+++ b/Common/Extensions/DictionaryExtensions.cs
@@ -31,6 +31,20 @@ namespace Common
             }
         }
 
+        public static bool TryGetValueOrDefaultIgnoringCase<V>(this IDictionary<string, object> dictionary, string key, out V value)
+        {
+            if (dictionary.TryGetValueIgnoringCase(key, out object objectValue) && objectValue is V)
+            {
+                value = (V)objectValue;
+                return true;
+            }
+            else
+            {
+                value = default;
+                return false;
+            }
+        }
+
         public static bool ContainsKeyIgnoringCase(this IDictionary<string, TargetFieldMap> dictionary, string desiredKeyOfAnyCase)
         {
             return GetKeyIgnoringCase(dictionary, desiredKeyOfAnyCase) != null;

--- a/Common/IContext.cs
+++ b/Common/IContext.cs
@@ -16,5 +16,9 @@ namespace Common
 
         //State of all work items to migrate
         ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; set; }
+
+        //remote relation types, do not need to exist on target since they're 
+        //recreated as hyperlinks
+        ConcurrentSet<string> RemoteLinkRelationTypes { get; set; }
     }
 }

--- a/Common/Migration/Contexts/IMigrationContext.cs
+++ b/Common/Migration/Contexts/IMigrationContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Common.Config;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 
 namespace Common.Migration

--- a/Common/Migration/Contexts/MigrationContext.cs
+++ b/Common/Migration/Contexts/MigrationContext.cs
@@ -7,25 +7,13 @@ using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 
 namespace Common.Migration
 {
-    public class MigrationContext : IMigrationContext
+    public class MigrationContext : BaseContext, IMigrationContext
     {
-        public ConfigJson Config { get; }
-
-        public WorkItemClientConnection SourceClient { get; }
-
-        public WorkItemClientConnection TargetClient { get; }
-
-        public ConcurrentDictionary<int, string> WorkItemIdsUris { get; set; }
-
-        public ConcurrentBag<WorkItemMigrationState> WorkItemsMigrationState { get; set; } = new ConcurrentBag<WorkItemMigrationState>();
-
-        public ConcurrentDictionary<int, int> SourceToTargetIds { get; set; } = new ConcurrentDictionary<int, int>();
-
         //Mapping of targetId of a work item to attribute id of the hyperlink
         public ConcurrentDictionary<int, Int64> TargetIdToSourceHyperlinkAttributeId { get; set; } = new ConcurrentDictionary<int, Int64>();
 
         public ConcurrentSet<string> ValidatedWorkItemLinkRelationTypes { get; set; } 
-        
+
         public ConcurrentDictionary<string, ISet<string>> WorkItemTypes { get; set; }
 
         public ConcurrentDictionary<string, WorkItemField> SourceFields { get; set; } = new ConcurrentDictionary<string, WorkItemField>(StringComparer.CurrentCultureIgnoreCase);
@@ -73,11 +61,8 @@ namespace Common.Migration
             "System.AreaLevel7"
         });
 
-        public MigrationContext(ConfigJson configJson)
+        public MigrationContext(ConfigJson configJson) : base(configJson)
         {
-            this.Config = configJson;
-            this.SourceClient = ClientHelpers.CreateClient(configJson.SourceConnection);
-            this.TargetClient = ClientHelpers.CreateClient(configJson.TargetConnection);
         }
     }
 }

--- a/Common/Migration/Phase2/Processors/RemoteLinksProcessor.cs
+++ b/Common/Migration/Phase2/Processors/RemoteLinksProcessor.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
+using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
+using Logging;
+using Microsoft.VisualStudio.Services.Common;
+using Common.Config;
+using System;
+
+namespace Common.Migration
+{
+    public class RemoteLinksProcessor : IPhase2Processor
+    {
+        private static ILogger Logger { get; } = MigratorLogging.CreateLogger<RemoteLinksProcessor>();
+
+        public string Name => Constants.RelationPhaseRemoteLinks;
+
+        public bool IsEnabled(ConfigJson config)
+        {
+            return config.MoveLinks;
+        }
+
+        public async Task Preprocess(IMigrationContext migrationContext, IBatchMigrationContext batchContext, IList<WorkItem> sourceWorkItems, IList<WorkItem> targetWorkItems)
+        {
+
+        }
+
+        public async Task<IEnumerable<JsonPatchOperation>> Process(IMigrationContext migrationContext, IBatchMigrationContext batchContext, WorkItem sourceWorkItem, WorkItem targetWorkItem)
+        {
+            IList<JsonPatchOperation> jsonPatchOperations = new List<JsonPatchOperation>();
+            IEnumerable<WorkItemRelation> sourceRemoteLinks = sourceWorkItem.Relations?.Where(r => RelationHelpers.IsRemoteLinkType(migrationContext, r.Rel));
+
+            if (sourceRemoteLinks != null && sourceRemoteLinks.Any())
+            {
+                foreach (WorkItemRelation sourceRemoteLink in sourceRemoteLinks)
+                {
+                    string url = ConvertRemoteLinkToHyperlink(sourceRemoteLink.Url);
+                    WorkItemRelation targetRemoteLinkHyperlinkRelation = GetHyperlinkIfExistsOnTarget(targetWorkItem, url);
+
+                    if (targetRemoteLinkHyperlinkRelation != null) // is on target
+                    {
+                        JsonPatchOperation remoteLinkHyperlinkAddOperation = MigrationHelpers.GetRelationAddOperation(targetRemoteLinkHyperlinkRelation);
+                        jsonPatchOperations.Add(remoteLinkHyperlinkAddOperation);
+                    }
+                    else // is not on target
+                    {
+                        string comment = string.Empty;
+                        if (sourceRemoteLink.Attributes.ContainsKey(Constants.RelationAttributeComment))
+                        {
+                            comment = $"{sourceRemoteLink.Attributes[Constants.RelationAttributeComment]}";
+                        }
+
+                        WorkItemRelation newRemoteLinkHyperlinkRelation = new WorkItemRelation();
+                        newRemoteLinkHyperlinkRelation.Rel = Constants.Hyperlink;
+                        newRemoteLinkHyperlinkRelation.Url = url;
+                        newRemoteLinkHyperlinkRelation.Attributes = new Dictionary<string, object>();
+                        newRemoteLinkHyperlinkRelation.Attributes[Constants.RelationAttributeComment] = comment;
+
+                        JsonPatchOperation remoteLinkHyperlinkAddOperation = MigrationHelpers.GetRelationAddOperation(newRemoteLinkHyperlinkRelation);
+                        jsonPatchOperations.Add(remoteLinkHyperlinkAddOperation);
+                    }
+                }
+            }
+
+            return jsonPatchOperations;
+        }
+
+        private WorkItemRelation GetHyperlinkIfExistsOnTarget(WorkItem targetWorkItem, string href)
+        {
+            if (targetWorkItem.Relations == null)
+            {
+                return null;
+            }
+
+            foreach (WorkItemRelation targetRelation in targetWorkItem.Relations)
+            {
+                if (targetRelation.Rel.Equals(Constants.Hyperlink) && targetRelation.Url.Equals(href, StringComparison.OrdinalIgnoreCase))
+                {
+                    return targetRelation;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Remote links returned refer to the REST reference, and we want the web reference.
+        /// Format: https://account.visualstudio.com/ad443396-8473-4678-a2ba-0b1cf7cc8837/_apis/wit/workItems/3915636
+        /// Web: https://account.visualstudio.com/ad443396-8473-4678-a2ba-0b1cf7cc8837/_workitems/edit/3915636
+        /// </summary>
+        /// <param name="url"></param>
+        /// <returns></returns>
+        private string ConvertRemoteLinkToHyperlink(string url)
+        {
+            return url.Replace("_apis/wit/workitems", "_workitems/edit", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Common/RelationHelpers.cs
+++ b/Common/RelationHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Common.Migration;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 
 namespace Common
@@ -38,6 +39,16 @@ namespace Common
             }
 
             return false;
+        }
+
+        public static bool IsRemoteLinkType(WorkItemRelationType relationType)
+        {
+            return relationType.Attributes.TryGetValueOrDefaultIgnoringCase<bool>(Constants.RemoteLinkAttributeKey, out var remote) && remote;
+        }
+
+        public static bool IsRemoteLinkType(IContext context, string relationReferenceName)
+        {
+            return context.RemoteLinkRelationTypes.Contains(relationReferenceName);
         }
     }
 }

--- a/Common/Validation/IValidationContext.cs
+++ b/Common/Validation/IValidationContext.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using Common.Config;
 using Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models;
 
 namespace Common.Validation

--- a/WiMigrator/CommandLine.cs
+++ b/WiMigrator/CommandLine.cs
@@ -136,6 +136,7 @@ namespace WiMigrator
                 migrationContext.WorkItemsMigrationState = validatorContext.WorkItemsMigrationState;
                 migrationContext.TargetIdToSourceHyperlinkAttributeId = validatorContext.TargetIdToSourceHyperlinkAttributeId;
                 migrationContext.ValidatedWorkItemLinkRelationTypes = validatorContext.ValidatedWorkItemLinkRelationTypes;
+                migrationContext.RemoteLinkRelationTypes = validatorContext.RemoteLinkRelationTypes;
                 migrationContext.SourceFields = validatorContext.SourceFields;
                 migrationContext.FieldsThatRequireSourceProjectToBeReplacedWithTargetProject = validatorContext.FieldsThatRequireSourceProjectToBeReplacedWithTargetProject;
 


### PR DESCRIPTION
With the recent addition of remote link support, we need to migrate them as a hyperlink instead of as a remote work item link.  If they were to migrate as the original remote work item link, the remote work item would be linked to both the migrated work item and the original work item.

Instead, we will migrate as a hyperlink.  