### PR TITLE
update iteration-path if different from source

### DIFF
--- a/Common/Config/ConfigJson.cs
+++ b/Common/Config/ConfigJson.cs
@@ -76,6 +76,10 @@ namespace Common.Config
         [DefaultValue(false)]
         public bool SkipWorkItemsWithMissingAreaPath { get; set; }
 
+        [JsonProperty(PropertyName = "update-work-items-with-different-iteration-path", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(false)]
+        public bool UpdateWorkItemsWithDifferentIterationPath { get; set; }
+
         [JsonProperty(PropertyName = "skip-work-items-with-missing-iteration-path", DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(false)]
         public bool SkipWorkItemsWithMissingIterationPath { get; set; }

--- a/Common/Migration/Phase1/Processors/UpdateWorkItemsProcessor.cs
+++ b/Common/Migration/Phase1/Processors/UpdateWorkItemsProcessor.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Common.Config;
 using Logging;
 using Microsoft.Extensions.Logging;
+using System;
 
 namespace Common.Migration
 {
@@ -30,6 +31,11 @@ namespace Common.Migration
                 var workItemMigrationState = workItemsAndStateToMigrate.Where(w => w.SourceId == sourceWorkItem.Id.Value).FirstOrDefault();
                 if (workItemMigrationState != null && workItemMigrationState.TargetId.HasValue)
                 {
+                    if(batchContext.WorkItemMigrationState
+                            .Where(a => a.SourceId == sourceWorkItem.Id && a.Requirement.HasFlag(WorkItemMigrationState.RequirementForExisting.UpdateChangedDate)).Count() == 1) {
+                        Logger.LogInformation($"Updating ChangedDate on work item with source id {sourceWorkItem.Id}");
+                        sourceWorkItem.Fields["System.ChangedDate"] = DateTime.Now;
+                    }
                     batchContext.TargetIdToSourceWorkItemMapping.Add(workItemMigrationState.TargetId.Value, sourceWorkItem);
                 }
                 else

--- a/Common/Validation/IValidationContext.cs
+++ b/Common/Validation/IValidationContext.cs
@@ -17,6 +17,7 @@ namespace Common.Validation
         ISet<string> RequestedFields { get; }
 
         ConcurrentDictionary<int, int> SourceWorkItemRevision { get; set; }
+        ConcurrentDictionary<int, string> SourceWorkItemIterationPath { get; set; }
 
         ConcurrentDictionary<string, WorkItemField> SourceFields { get; set; }
 

--- a/Common/Validation/Target/ValidateTargetWorkItems.cs
+++ b/Common/Validation/Target/ValidateTargetWorkItems.cs
@@ -162,9 +162,16 @@ namespace Common.Validation
             else if (IsPhase2UpdateRequired(workItemMigrationState, targetWorkItem))
             {
                 workItemMigrationState.Requirement |= WorkItemMigrationState.RequirementForExisting.UpdatePhase2;
-            }
-            else
-            {
+            } else if (ValidationContext.Config.UpdateWorkItemsWithDifferentIterationPath == true && 
+                        !ValidationContext.SourceWorkItemIterationPath[(int)sourceId].Equals(targetWorkItem.Fields["System.IterationPath"]) 
+                    ) {
+                    workItemMigrationState.Requirement |= WorkItemMigrationState.RequirementForExisting.None;
+                    this.sourceWorkItemIdsThatHaveBeenUpdated.Add(sourceId);
+                    workItemMigrationState.Requirement |= WorkItemMigrationState.RequirementForExisting.UpdatePhase1;
+                    workItemMigrationState.Requirement |= WorkItemMigrationState.RequirementForExisting.UpdatePhase2;
+                    workItemMigrationState.Requirement |= WorkItemMigrationState.RequirementForExisting.UpdateChangedDate;
+                    Logger.LogInformation($"Work item with id {workItemMigrationState.SourceId} has different iteration path than target. Will update target (id {targetWorkItem.Id})");
+            } else {
                 workItemMigrationState.Requirement |= WorkItemMigrationState.RequirementForExisting.None;
             }
         }

--- a/Common/Validation/ValidationContext.cs
+++ b/Common/Validation/ValidationContext.cs
@@ -22,8 +22,10 @@ namespace Common.Validation
 
         public ConcurrentDictionary<int, int> SourceWorkItemRevision { get; set; } = new ConcurrentDictionary<int, int>();
 
-        public ConcurrentDictionary<string, WorkItemField> SourceFields { get; set; } = new ConcurrentDictionary<string, WorkItemField>(StringComparer.OrdinalIgnoreCase);
+        public ConcurrentDictionary<int, String> SourceWorkItemIterationPath { get; set; } = new ConcurrentDictionary<int, string>();
 
+        public ConcurrentDictionary<string, WorkItemField> SourceFields { get; set; } = new ConcurrentDictionary<string, WorkItemField>(StringComparer.OrdinalIgnoreCase);
+        
         public ConcurrentDictionary<string, WorkItemField> TargetFields { get; set; } = new ConcurrentDictionary<string, WorkItemField>(StringComparer.OrdinalIgnoreCase);
 
         public ConcurrentDictionary<string, ISet<string>> SourceTypesAndFields { get; } = new ConcurrentDictionary<string, ISet<string>>(StringComparer.OrdinalIgnoreCase);

--- a/Common/Validation/Validator.cs
+++ b/Common/Validation/Validator.cs
@@ -138,6 +138,9 @@ namespace Common.Validation
                     foreach (var workItem in workItems)
                     {
                         await validator.Validate(context, workItem);
+
+                        // Track iteration paths for sourcework items
+                        context.SourceWorkItemIterationPath[(int)workItem.Id] = workItem.Fields["System.IterationPath"].ToString();
                     }
                 }
 

--- a/Common/WorkItemMigrationState.cs
+++ b/Common/WorkItemMigrationState.cs
@@ -16,7 +16,7 @@ namespace Common
         public enum State { Create, Existing, Error }
 
         [Flags]
-        public enum RequirementForExisting { None, UpdatePhase1, UpdatePhase2 }
+        public enum RequirementForExisting { None, UpdatePhase1, UpdatePhase2, UpdateChangedDate=4 }
         [Flags]
         public enum MigrationCompletionStatus { None, Phase1, Phase2, Phase3 }
         public RevAndPhaseStatus RevAndPhaseStatus { get; set; }

--- a/WiMigrator/migration-configuration.md
+++ b/WiMigrator/migration-configuration.md
@@ -56,6 +56,8 @@
 
 #### ```skip-work-items-with-missing-iteration-path``` when true, will skip the work item if the iteration path does not exist in the target account when false, will migrate the work item and set the iteration path to the project name when the iteration path does not exist on the target account.
 
+#### ```update-work-items-with-different-iteration-path``` when true, will update the iteration-path on the target work item if it's different than the source
+
 #### ```default-area-path``` when the area path doesn't exist on the target project, the migrator will use this area path instead of defaulting to the root. note: if skip-work-items-with-missing-area-path is true, this setting is ignored.
 
 #### ```default-iteration-path``` when the iteration path doesn't exist on the target project, the migrator will use this iteration path instead of defaulting to the root. note: if skip-work-items-with-missing-iteration-path is true, this setting is ignored.

--- a/WiMigrator/sample-configuration.json
+++ b/WiMigrator/sample-configuration.json
@@ -28,6 +28,7 @@
   "target-post-move-tag": "6F078B6C-2A96-453B-A7C3-EACE6E63BB97",
   "skip-work-items-with-type-missing-fields": false,
   "skip-work-items-with-missing-area-path": false,
+  "update-work-items-with-different-iteration-path": false,
   "skip-work-items-with-missing-iteration-path": false,
   "default-area-path": "contoso-project\\missing area path",
   "default-iteration-path": "contoso-project\\missing iteration path",


### PR DESCRIPTION
The motivation for adding this feature was that work-items was already migrated without the iteration-paths being registered on the target, and also changed iteration-path names on the source after first migrations. In order not having to update all the work-items on the source, rather adding the option to update the target if the iteration-path is different.